### PR TITLE
Fix keybind name printing

### DIFF
--- a/src/main/java/club/sk1er/popupevents/render/ConfirmationPopup.java
+++ b/src/main/java/club/sk1er/popupevents/render/ConfirmationPopup.java
@@ -14,6 +14,7 @@ import net.minecraft.client.audio.SoundHandler;
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.gui.Gui;
 import net.minecraft.client.gui.ScaledResolution;
+import net.minecraft.client.settings.GameSettings;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
@@ -242,8 +243,8 @@ public class ConfirmationPopup {
 
                 fr.drawString(text, resolution.getScaledWidth() / 2 - fr.getStringWidth(text) / 2, 58, -1);
                 String acceptDeny =
-                    EnumChatFormatting.GREEN + "[" + Keyboard.getKeyName(PopupEvents.instance.getKeybindAccept().getKeyCode()) + "] Accept " +
-                        EnumChatFormatting.RED + "[" + Keyboard.getKeyName(PopupEvents.instance.getKeybindDeny().getKeyCode()) + "] Deny";
+                        EnumChatFormatting.GREEN + "[" + GameSettings.getKeyDisplayString(PopupEvents.instance.getKeybindAccept().getKeyCode()) + "] Accept " +
+                        EnumChatFormatting.RED + "[" + GameSettings.getKeyDisplayString(PopupEvents.instance.getKeybindDeny().getKeyCode()) + "] Deny";
                 fr.drawString(acceptDeny, resolution.getScaledWidth() / 2 - fr.getStringWidth(acceptDeny) / 2, 70, -1);
             }
 


### PR DESCRIPTION
Binding the accept or deny keybind to a non-keyboard key or a key without an LWJGL 2 keycode would cause a crash. This fixes it (by using Minecraft's own method for getting the key name)

I noticed this issue because https://discordapp.com/channels/411619823445999637/412310617442091008/743139698352062502
so I guess I can also say that this fixes a crash.